### PR TITLE
CI: fix deprecated actions/cache@v2 (was breaking the Pages deploy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
GitHub now automatically fails any workflow using `actions/cache@v2`, which was causing the **Deploy Next.js site to Pages** and **ci** workflows to fail at "Set up job" — so the live site hadn't been deploying. Bumped to `actions/cache@v4` in both workflows. (Pre-existing infra breakage, surfaced while resolving the issue/PR backlog.)